### PR TITLE
Allowed add more dictionary to CensorWords

### DIFF
--- a/tests/CensorTest.php
+++ b/tests/CensorTest.php
@@ -13,6 +13,20 @@ class CensorTest extends PHPUnit_Framework_TestCase {
     $censor->setDictionary('fr');
     $this->assertNotEmpty($censor->badwords);
   }
+
+  public function testAddDictionary()
+  {
+    $censor = new CensorWords();
+    $censor->addDictionary('fr');
+
+    $this->assertNotEmpty($censor->badwords);
+
+    $string1 = $censor->censorString('fuck');
+    $this->assertEquals('****', $string1['clean']);
+
+    $string2 = $censor->censorString('nique');
+    $this->assertEquals('*****', $string2['clean']);
+  }
   
   /**
   * @expectedException PHPUnit_Framework_Error


### PR DESCRIPTION
- Moved code read bad words from dictionary to `readBadWords()` function for reuse.
- Added `addDictionary()` function to read from dictionary and merge the result with current `$badwords` list.
- In the previous code, you setted `$this->dictionary = $dictionary`, but it only used by `setDictionary()` function. I'm not sure if anyone using this bundle try to access the public member, but I think remove it will make code simpler (don't need to append when add more... etc), more OOP (restrict public member).
