### PR TITLE
Update docs to reflect available languages

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,10 @@ $string = $censor->censorString($yourstring);</code></pre>
 			<li>French - France (fr)</li>
 			<li>Dutch - Netherlands (nl)</li>
 			<li>Norwegian - Bokm&aring;l & various dialects - (no)</li>
+			<li>German (de) - rudimentary</li>
+			<li>Finnish (fi)</li>
+			<li>Italian (it)</li>
+			<li>Japanese (jp)</li>
 		</ul>
 		
 		<p>To choose a non-English language file (or several dictionaries at once), 


### PR DESCRIPTION
Not sure if the ```en-base``` should also be added to the docs.