### PR TITLE
Fixes #39

### DIFF
--- a/src/CensorWords.php
+++ b/src/CensorWords.php
@@ -61,7 +61,6 @@ class CensorWords
             foreach ($dictionary as $dictionary_file) {
                 $badwords = array_merge($badwords, $this->readBadWords($dictionary_file));
             }
-            $badwords = array_unique($badwords);
 
             // just a single string, not an array
         } elseif (is_string($dictionary)) {
@@ -72,7 +71,7 @@ class CensorWords
             }
         }
 
-        return  $badwords;
+        return  array_values(array_unique($badwords));
 	}
 
 	/**


### PR DESCRIPTION
The problem is caused when calling setDictionary() with an array of languages, and the array_unique() call on https://github.com/snipe/banbuilder/blob/master/src/CensorWords.php#L64 within that method removes items from the badwords array. The problem itself is that the remaining keys are not sequential, but the loop inside the generateCensorChecks() method on https://github.com/snipe/banbuilder/blob/master/src/CensorWords.php#L146 does expect them to be sequential. The result is a `undefined index` error. This change fixes that issue, and also improves performance by removing duplicate badwords if there are any, after calling readBadwords(), e.g. via multiple calls to addDictionary(), with a string argument, instead of an array.