### PR TITLE
Fix typo in the addWhiteList method name

### DIFF
--- a/src/CensorWords.php
+++ b/src/CensorWords.php
@@ -89,7 +89,7 @@ class CensorWords
      *
      * @param array $list
      */
-    public function addWhileList(array $list)
+    public function addWhiteList(array $list)
     {
         foreach ($list as $value) {
             if (is_string($value) && !empty($value)) {

--- a/tests/CensorTest.php
+++ b/tests/CensorTest.php
@@ -113,7 +113,7 @@ class CensorTest extends TestCase
   public function testWhiteListCensorObj()
   {
     $censor = new CensorWords;
-    $censor->addWhileList([
+    $censor->addWhiteList([
         'fuck',
         'ass',
         'Mass',


### PR DESCRIPTION
It says "addWhileList" when it should say "addWhiteList".

Arguably, since "whitelist" is commonly accepted as one word, the "L" should be lowercase - but that's pretty minor. As long as it's consistent, it's fine.