### PR TITLE
Fix build errors & add a new RuntimeException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
  
 before_script:
   - composer self-update

--- a/src/CensorWords.php
+++ b/src/CensorWords.php
@@ -60,29 +60,37 @@ class CensorWords
     /**
      * Read bad words list from dictionar(y|ies) and return it
      *
-     * @param        string /array
+     * @param       string|array        a language identifier or path for a dictionary (or an array of identifiers/paths)
      *
-     * @return array
+     * @throws      \RuntimeException   if a dictionary file is not found
+     *
+     * @return      array               de-duplicated array of bad words
      */
     private function readBadWords($dictionary)
     {
         $badwords     = array();
-        $baseDictPath = __DIR__ . DIRECTORY_SEPARATOR . 'dict/';
+        $baseDictPath = __DIR__ . DIRECTORY_SEPARATOR . 'dict' . DIRECTORY_SEPARATOR;
 
         if (is_array($dictionary)) {
             foreach ($dictionary as $dictionary_file) {
                 $badwords = array_merge($badwords, $this->readBadWords($dictionary_file));
             }
-            // just a single string, not an array
-        } elseif (is_string($dictionary)) {
+        }
+
+        // just a single string, not an array
+        if (is_string($dictionary)) {
             if (file_exists($baseDictPath . $dictionary . '.php')) {
                 include $baseDictPath . $dictionary . '.php';
-            } else {
+            } elseif (file_exists($dictionary)) {
                 include $dictionary;
+            } else {
+                throw new \RuntimeException('Dictionary file not found: ' . $dictionary);
             }
         }
 
-        return array_values(array_unique($badwords));
+        // counting values and then only returning the keys is said
+        // to be more efficient than array_values(array_unique())
+        return array_keys(array_count_values($badwords));
     }
 
     /**

--- a/src/CensorWords.php
+++ b/src/CensorWords.php
@@ -36,8 +36,8 @@ class CensorWords
      *  This can accept a string to a language file path,
      *  or an array of strings to multiple paths
      *
-     * @param        string /array
-     *                      string
+     *  @param		string|array
+     *  @throws     \RuntimeException   if a dictionary file is not found
      */
     public function setDictionary($dictionary)
     {
@@ -49,8 +49,8 @@ class CensorWords
      *  This can accept a string to a language file path,
      *  or an array of strings to multiple paths
      *
-     * @param        string /array
-     *                      string
+     *  @param		string|array
+     *  @throws     \RuntimeException   if a dictionary file is not found
      */
     public function addDictionary($dictionary)
     {

--- a/tests/CensorTest.php
+++ b/tests/CensorTest.php
@@ -30,7 +30,7 @@ class CensorTest extends TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException RuntimeException
      */
     public function testInvalidDictionaryException()
     {


### PR DESCRIPTION
I was attempting to get builds working but I don't have PHP7.1 locally at the moment, so I am hoping Travis will be happy. May need to remove hhvm from travis.yml.

As part of this initiative, I added a RuntimeException to readBadWords. This is a BC break, I guess? So with semver in mind, may want to discuss whether it's the ideal approach or not.

Also, PHPStorm recommended a different (allegedly faster) way of de-duplicating the bad words array, so I put that in.